### PR TITLE
MIDI clock slave mode: fix timing and note-off behavior

### DIFF
--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -107,16 +107,15 @@ function Clock (client) {
         if (performance.now() - pulse.last < 2000) { return }
         this.untap()
       }, 2000)
-    } else {
-      if (pulse.count == 0) {
-        if (this.isPaused) { pulse.frame++ }
-        else {
-          if (pulse.frame > 0) {
-            this.setFrame(client.orca.f + pulse.frame)
-            pulse.frame = 0
-          }
-          client.run()
+    }
+    if (pulse.count == 0) {
+      if (this.isPaused) { pulse.frame++ }
+      else {
+        if (pulse.frame > 0) {
+          this.setFrame(client.orca.f + pulse.frame)
+          pulse.frame = 0
         }
+        client.run()
       }
     }
   }

--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -127,7 +127,9 @@ function Clock (client) {
     this.isPuppet = false
     pulse.frame = 0
     pulse.last = null
-    this.setTimer(this.speed.value)
+    if (!this.isPaused) {
+      this.setTimer(this.speed.value)
+    }
   }
 
   // Timer

--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -56,13 +56,13 @@ function Clock (client) {
     client.update()
   }
 
-  this.play = function (msg = false, force = false) {
-    console.log('Clock', 'Play', msg, force)
-    if (this.isPaused === false && !force) { return }
+  this.play = function (msg = false, midiStart = false) {
+    console.log('Clock', 'Play', msg, midiStart)
+    if (this.isPaused === false && !midiStart) { return }
     this.isPaused = false
     if (this.isPuppet === true) {
       console.warn('Clock', 'External Midi control')
-      if (!pulse.frame || force) {  // no frames counted while paused or restard demanded (via MIDI clock START)
+      if (!pulse.frame || midiStart) {  // no frames counted while paused (starting from no clock, unlikely) or triggered by MIDI clock START
         this.setFrame(0)  // make sure frame aligns with pulse count for an accurate beat
         pulse.frame = 0
         pulse.count = 5   // by MIDI standard next pulse is the beat

--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -60,19 +60,27 @@ function Clock (client) {
     console.log('Clock', 'Play', msg)
     if (this.isPaused === false) { return }
     this.isPaused = false
-    if (this.isPuppet === true) { console.warn('Clock', 'External Midi control'); return }
-    if (msg === true) { client.io.midi.sendClockStart() }
-    this.setSpeed(this.speed.target, this.speed.target, true)
+    if (this.isPuppet === true) { 
+      console.warn('Clock', 'External Midi control')
+      pulse.count = 0  // works in conjunction with `tap` advancing on 0
+      this.setFrame(0)  // make sure frame aligns with pulse count for an accurate beat
+    } else {
+      if (msg === true) { client.io.midi.sendClockStart() }
+      this.setSpeed(this.speed.target, this.speed.target, true)
+    }
   }
 
   this.stop = function (msg = false) {
     console.log('Clock', 'Stop')
     if (this.isPaused === true) { return }
     this.isPaused = true
-    if (this.isPuppet === true) { console.warn('Clock', 'External Midi control'); return }
-    if (msg === true || client.io.midi.isClock) { client.io.midi.sendClockStop() }
+    if (this.isPuppet === true) { 
+      console.warn('Clock', 'External Midi control')
+    } else {
+      if (msg === true || client.io.midi.isClock) { client.io.midi.sendClockStop() }
+      this.clearTimer()
+    }
     client.io.midi.allNotesOff()
-    this.clearTimer()
     client.io.midi.silence()
   }
 
@@ -92,11 +100,8 @@ function Clock (client) {
       }, 2000)
     }
     if (this.isPaused) { return }
-    pulse.count = pulse.count + 1
-    if (pulse.count % 6 === 0) {
-      client.run()
-      pulse.count = 0
-    }
+    if (pulse.count == 0) { client.run() }
+    pulse.count = (pulse.count + 1) % 6
   }
 
   this.untap = function () {

--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -58,11 +58,11 @@ function Clock (client) {
 
   this.play = function (msg = false, force = false) {
     console.log('Clock', 'Play', msg, force)
-    if (this.isPaused === false) { return }
+    if (this.isPaused === false && !force) { return }
     this.isPaused = false
     if (this.isPuppet === true) {
       console.warn('Clock', 'External Midi control')
-      if (!pulse.frame || force) {  // no frames counted while paused or restard demanded (via MIDI clock PLAY)
+      if (!pulse.frame || force) {  // no frames counted while paused or restard demanded (via MIDI clock START)
         this.setFrame(0)  // make sure frame aligns with pulse count for an accurate beat
         pulse.frame = 0
         pulse.count = 5   // by MIDI standard next pulse is the beat

--- a/desktop/sources/scripts/core/io/midi.js
+++ b/desktop/sources/scripts/core/io/midi.js
@@ -129,7 +129,7 @@ function Midi (client) {
         break
       case 0xFA:
         console.log('MIDI', 'Start Received')
-        client.clock.play()
+        client.clock.play(false, true)
         break
       case 0xFB:
         console.log('MIDI', 'Continue Received')


### PR DESCRIPTION
- `play()` will reset both frame and pulse counts to 0, for alignment
- `stop()` will silence
- `tap()` will `update` immediately upon play(), not on the next frame